### PR TITLE
feat: Adding Add to Cart steps to the test

### DIFF
--- a/tests/swaglabs.spec.ts
+++ b/tests/swaglabs.spec.ts
@@ -23,6 +23,13 @@ test.describe('SwagLabs Tests', () => {
     await page.click(dataTestLoginButton);
 
     await expect(page).toHaveURL(/inventory.html/);
+    
+    const firstProductFromInventory = page.getByRole("button", {name: "Add to cart"}).nth(0)
+    await firstProductFromInventory.click()
+
+    const removeProductFromCartButton = page.getByRole("button", {name: "Remove"})
+    await expect(removeProductFromCartButton).toBeVisible()
+    
     await page.screenshot({ path: 'example.png' });
   });
 


### PR DESCRIPTION
Addition of the 'Add to Cart' steps to 'User can login succesfully' test on swaglabs.spec.ts file.

I chose to use **_locator.click()_** in opposition to **_page.click()_** to be able to use **_nth()_** method to ensure that the desired product is actually added to the cart.

To assert that the product is actually added I chose to expect the _**Remove**_ button to be visible.